### PR TITLE
JsChecker: support extensionless ES6 imports

### DIFF
--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -237,3 +237,27 @@ sh_test(
         ":exports_data",
     ],
 )
+
+# TEST: ES6 module can import another via a workspace-relative extensionless import path.
+
+closure_js_library(
+    name = "es6module1",
+    srcs = ["es6module1.js"],
+    no_closure_library = True,
+)
+
+closure_js_library(
+    name = "es6module2",
+    srcs = ["es6module2.js"],
+    #    suppress = ["moduleLoad"],
+    no_closure_library = True,
+    deps = [":es6module1"],
+)
+
+closure_js_binary(
+    name = "es6module_bin",
+    compilation_level = "ADVANCED",
+    entry_points = ["/closure/compiler/test/es6module2"],
+    language = "ECMASCRIPT5",
+    deps = [":es6module2"],
+)

--- a/closure/compiler/test/es6module1.js
+++ b/closure/compiler/test/es6module1.js
@@ -1,0 +1,15 @@
+// Copyright 2019 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const name = "module1";

--- a/closure/compiler/test/es6module2.js
+++ b/closure/compiler/test/es6module2.js
@@ -1,0 +1,17 @@
+// Copyright 2019 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { name } from "/closure/compiler/test/es6module1";
+
+console.log(name);

--- a/java/com/google/javascript/jscomp/CheckStrictDeps.java
+++ b/java/com/google/javascript/jscomp/CheckStrictDeps.java
@@ -136,6 +136,12 @@ abstract class CheckStrictDeps
     private void checkNamespaceIsProvided(NodeTraversal t, Node n, String namespace) {
       if (namespace.startsWith("/") || namespace.startsWith(".")) {
         // TODO(jart): Unify path resolution with ModuleLoader.
+        // NOTE(robfig): To enable usage of extensionless ES6 modules,
+        // copy these 3 lines from NodeModuleResolver.java.
+        if (!namespace.endsWith(".js")) {
+          namespace += ".js";
+        }
+
         Webpath me = Webpath.get(t.getSourceName());
         if (!me.isAbsolute()) {
           me = Webpath.get("/").resolve(me);


### PR DESCRIPTION
Cross post from https://github.com/bazelbuild/rules_closure/pull/409

I'm not sure if this is the best way to accomplish it, but it's working for us and I didn't see an obvious alternative. We now have some hundreds of files using workspace-relative absolute extensionless ES6 imports and it all works fine with rules_closure & jsx.
